### PR TITLE
net/freeradius: options for defining Fallback VLAN

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.16
+PLUGIN_VERSION=		1.9.17
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -15,6 +15,10 @@ The server is fast, feature-rich, modular, and scalable.
 Plugin Changelog
 ================
 
+1.9.17
+
+* Allow user to define Fallback VlAN
+
 1.9.16
 
 * Allow user to choose Elliptic Curve in EAP

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -12,6 +12,18 @@
         <help>This allows you to dynamically assign VLANs on your physical switch ports.</help>
     </field>
     <field>
+        <id>general.fallbackvlan_enabled</id>
+        <label>Enable VLAN fallback assignment</label>
+        <type>checkbox</type>
+        <help>This allows you to define a fallback VLAN-Group-ID.</help>
+    </field>
+    <field>
+        <id>general.fallbackvlan_id</id>
+        <label>Fallback VLAN id</label>
+        <type>text</type>
+        <help>Define the Fallback VLAN group id.</help>
+    </field>
+    <field>
         <id>general.ldap_enabled</id>
         <label>Enable LDAP</label>
         <type>checkbox</type>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -11,6 +11,14 @@
             <default>0</default>
             <Required>N</Required>
         </vlanassign>
+        <fallbackvlan_enabled type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </fallbackvlan_enabled>
+        <fallbackvlan_id type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>4096</MaximumValue>
+        </fallbackvlan_id>
         <ldap_enabled type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -85,4 +85,12 @@ DEFAULT Hint == "CSLIP"
 
 DEFAULT Hint == "SLIP"
         Framed-Protocol = SLIP
+
+{%  if helpers.exists('OPNsense.freeradius.general.fallbackvlan_enabled') and OPNsense.freeradius.general.fallbackvlan_enabled == '1' %}
+DEFAULT Auth-Type := Accept
+       Tunnel-Type = VLAN,
+       Tunnel-Medium-Type = IEEE-802,
+       Tunnel-Private-Group-Id = {{ OPNsense.freeradius.general.fallbackvlan_id }},
+       Framed-Protocol = PPP
+{%  endif %}
 {% endif %}


### PR DESCRIPTION
I have defined options fields in the general tab to be able to define a fallback group id and activate the option. also I have changed the config template for user-file generation to add the configured parameters when activated